### PR TITLE
Bump cargo version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "libz-sys"
-version = "1.0.3"
+version = "1.0.4"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 links = "z"
 build = "build.rs"


### PR DESCRIPTION
r? @alexcrichton 

We need a bump of the cargo version to pick up the Android cross-build fix for Servo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alexcrichton/libz-sys/7)
<!-- Reviewable:end -->
