### PR TITLE
use static or dynamic build of zlib from vcpkg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ libc = "0.2"
 [build-dependencies]
 pkg-config = "0.3"
 gcc = "0.3.17"
+
+[target.'cfg(target_env = "msvc")'.build-dependencies]
+vcpkg = "0.2"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,9 @@ environment:
     MSYS_BITS: 32
   - TARGET: x86_64-pc-windows-msvc
   - TARGET: i686-pc-windows-msvc
+  - TARGET: x86_64-pc-windows-msvc
+    VCPKG_DEFAULT_TRIPLET: x64-windows-static
+    RUSTFLAGS: -Ctarget-feature=+crt-static
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
   - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
@@ -13,6 +16,10 @@ install:
   - if defined MSYS_BITS set PATH=%PATH%;C:\msys64\mingw%MSYS_BITS%\bin;C:\msys64\usr\bin
   - rustc -V
   - cargo -V
+  - if defined VCPKG_DEFAULT_TRIPLET git clone https://github.com/Microsoft/vcpkg c:\projects\vcpkg
+  - if defined VCPKG_DEFAULT_TRIPLET c:\projects\vcpkg\bootstrap-vcpkg.bat
+  - if defined VCPKG_DEFAULT_TRIPLET set VCPKG_ROOT=c:\projects\vcpkg
+  - if defined VCPKG_DEFAULT_TRIPLET %VCPKG_ROOT%\vcpkg.exe install zlib
 
 build: false
 


### PR DESCRIPTION
Use zlib from vcpkg. This one is not behind a feature flag but the vcpkg build helper has similar opt-out mechanisms to pkg-config.

This would be required in order to merge https://github.com/alexcrichton/curl-rust/pull/166.