### PR TITLE
nmake chokes on MAKEFLAGS for jobserver (unmergeable repro)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -185,6 +185,7 @@ fn build_msvc_zlib(target: &str) {
 
     let nmake = gcc::windows_registry::find(target, "nmake.exe");
     let mut nmake = nmake.unwrap_or(Command::new("nmake.exe"));
+    nmake.env_remove("MAKEFLAGS");
     run(nmake.current_dir(dst.join("build"))
              .arg("/nologo")
              .arg("/f")


### PR DESCRIPTION
```
NMAKE : fatal error U1065: invalid option '-'
Stop.
Command exited with code 101
```