### PR TITLE
Use gmake on DragonFly as well

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -89,7 +89,7 @@ fn build_zlib() {
 }
 
 fn make() -> Command {
-    let cmd = if cfg!(target_os = "freebsd") {"gmake"} else {"make"};
+    let cmd = if cfg!(any(target_os = "freebsd", target_os = "dragonfly")) {"gmake"} else {"make"};
     let mut cmd = Command::new(cmd);
     // We're using the MSYS make which doesn't work with the mingw32-make-style
     // MAKEFLAGS, so remove that from the env if present.


### PR DESCRIPTION
Note: This applies to all other BSDs as well. Hard coding it in this way
should be generally avoided if possible.