### PR TITLE
Fix contribution notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ at your option.
 ### Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in Serde by you, as defined in the Apache-2.0 license, shall be
+for inclusion in `libz-sys` by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.


### PR DESCRIPTION
The README says "...for inclusion in Serde..." but I guess it meant to say "...for inclusion in libz-sys...".