### PR TITLE
Update `systest` dependencies

### DIFF
--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -6,7 +6,7 @@ build = "build.rs"
 
 [dependencies]
 libz-sys = { path = ".." }
-libc = "0.1"
+libc = "0.2"
 
 [build-dependencies]
-ctest = { git = "https://github.com/alexcrichton/ctest" }
+ctest = "0.1"


### PR DESCRIPTION
Updates the `systest` crate's dependencies.

`libc` was updated from 0.1 to 0.2, and `ctest` was set to version 0.1