### PR TITLE
Fix MinGW build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -134,6 +134,7 @@ fn build_zlib_mingw() {
         cflags.push(arg);
         cflags.push(" ");
     }
+    cflags.push("-Wno-error ");
     let gcc = sanitize_sh(compiler.path());
     let mut cmd = make();
     cmd.arg("-f").arg("win32/Makefile.gcc")


### PR DESCRIPTION
This pull request attempts to fix 32-bit MinGW builds, which fail due to `-Werror` being enabled.