### PR TITLE
Use C calling convention everywhere

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,12 +66,7 @@ pub type z_streamp = *mut z_stream;
 macro_rules! fns {
     ($($arg:tt)*) => {
         item! {
-            #[cfg(all(target_env = "msvc", target_pointer_width = "32"))]
             extern { $($arg)* }
-        }
-        item! {
-            #[cfg(not(all(target_env = "msvc", target_pointer_width = "32")))]
-            extern "system" { $($arg)* }
         }
     }
 }


### PR DESCRIPTION
`zlib` can be built to use the `__stdcall` calling convention on Windows, but it prefers to use `__cdecl` wherever possible.

From the `zlib` readme for Windows:

> There is also an **official** DLL build of zlib, named zlib1.dll. This one
> is exporting the functions using the CDECL convention. See the file
> win32\DLL_FAQ.txt found in this zlib distribution.

This issue was not found before because:
- on 64-bit Windows and all other platforms, `extern "system"` is the same as `extern`.
- 32-bit MSVC doesn't even check for calling conventions.
- 32-bit GCC did produce errors, but they were unclear (unlike the Rust compiler, it does not say which part of the function type is wrong).

Fixes `i686-pc-windows-gnu` builds.