### PR TITLE
Define _C99_SOURCE for iOS targets

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -106,6 +106,9 @@ fn build_zlib(cfg: &mut cc::Build, target: &str) {
         cfg.define("_POSIX_SOURCE", None);
         cfg.flag("-fvisibility=hidden");
     }
+    if target.contains("ios") {
+        cfg.define("_C99_SOURCE", None);
+    }
     if target.contains("solaris") {
         cfg.define("_XOPEN_SOURCE", "700");
     }


### PR DESCRIPTION
It seems that snprintf and family are feature-gated behind either
`_POSIX_C_SOURCE=200112L`, `_C99_SOURCE`, or `__cplusplus` within the iOS 12
SDK stdio.h decls. This change gives successful cross-compilation
builds (from host `x86_64-apple-darwin`) for:
* `aarch64-apple-ios`
* `armv7-apple-ios`
* `armv7s-apple-ios`
* `x86_64-apple-ios`
* `i386-apple-ios`

Fixes #44 