### PR TITLE
Add 'static' feature to build a statically linked crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,5 @@ vcpkg = "0.2"
 # noted in `contrib/README.contrib`, these routines are experimental and not
 # vetted, use at your own risk!
 asm = []
+# Enable this feature if you want to have a staticly linked libz
+static = []

--- a/build.rs
+++ b/build.rs
@@ -21,7 +21,8 @@ fn main() {
     // also don't run pkg-config on macOS/FreeBSD/DragonFly. That'll end up printing
     // `-L /usr/lib` which wreaks havoc with linking to an OpenSSL in /usr/local/lib
     // (Homebrew, Ports, etc.)
-    let want_static = env::var("LIBZ_SYS_STATIC").unwrap_or(String::new()) == "1";
+    let want_static =
+        cfg!(feature = "static") || env::var("LIBZ_SYS_STATIC").unwrap_or(String::new()) == "1";
     if !wants_asm &&
        !want_static &&
        !target.contains("msvc") && // pkg-config just never works here

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -10,3 +10,6 @@ libc = "0.2"
 
 [build-dependencies]
 ctest = "0.1"
+
+[features]
+libz-static = ["libz-sys/static"]


### PR DESCRIPTION
There is a way to build statically linked crate right now, however, it requires the environment variable `LIBZ_SYS_STATIC=1`. This can be suboptimal when as it makes the build to not be self-contained.
This PR adds feature `static` that triggers the same processing as the env var.